### PR TITLE
Fix property setting

### DIFF
--- a/src/new.luau
+++ b/src/new.luau
@@ -28,7 +28,7 @@ return (
 
 				if props then
 					for prop, value in props :: any do
-						if prop == "Parent" or "Name" then
+						if prop == "Parent" or prop == "Name" then
 							continue
 						end
 						Apply(New, prop, value)


### PR DESCRIPTION
In commit 371c108bcf1fe20311dc60cceea8b9f9b103e13a, support for setting object names was added. However, the implementation contained a bug that prevents any properties from being set. This PR resolves the issue.