### PR TITLE
fix: update Pesde package index endpoint

### DIFF
--- a/pesde.toml
+++ b/pesde.toml
@@ -17,7 +17,7 @@ lib = "src/init.luau"
 build_files = ["src"]
 
 [indices]
-default = "https://github.com/daimond113/pesde-index"
+default = "https://github.com/pesde-pkg/index"
 
 [scripts]
 roblox_sync_config_generator = ".pesde/scripts/roblox_sync_config_generator.luau"


### PR DESCRIPTION
Updates the Pesde package index url to the [new repo](https://github.com/pesde-pkg/index).